### PR TITLE
ci: add clippy and fmt jobs to existing Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,36 @@ jobs:
         run: cargo test --locked
 
 
+  clippy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./accounting_system_rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ./accounting_system_rust
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./accounting_system_rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
   docker_image:
     needs:
       - build


### PR DESCRIPTION
## Summary
- Adds `clippy` and `fmt` jobs to the existing `rust.yml` workflow
- Closes the gap left by closing #22 (which duplicated the existing test job)
- Both jobs reuse `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` for consistency and caching

## Changes
- `clippy`: runs `cargo clippy --workspace -- -D warnings`
- `fmt`: runs `cargo fmt --all -- --check`
- Existing `build` and `docker_image` jobs are untouched